### PR TITLE
fix: サムネイル生成時の日本語文字化けを解消

### DIFF
--- a/.github/workflows/marp-to-html-and-sync.yml
+++ b/.github/workflows/marp-to-html-and-sync.yml
@@ -21,6 +21,13 @@ jobs:
         with:
           node-version: '20'
 
+      # 日本語フォントをインストール（Marp/Puppeteer によるPNGレンダリングに必要）
+      - name: Install Japanese fonts
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y fonts-noto-cjk
+          fc-cache -fv
+
       # Marp CLIでHTMLを生成
       - name: Install Marp CLI
         run: npm install -g @marp-team/marp-cli

--- a/themes/aws-whatsnew.css
+++ b/themes/aws-whatsnew.css
@@ -21,7 +21,7 @@
 section {
   background: linear-gradient(135deg, var(--aws-squid-ink) 0%, #1a242f 100%);
   color: var(--aws-white);
-  font-family: 'Amazon Ember', 'Helvetica Neue', Arial, sans-serif;
+  font-family: 'Amazon Ember', 'Helvetica Neue', Arial, 'Noto Sans CJK JP', 'Noto Sans JP', 'Hiragino Kaku Gothic ProN', 'Yu Gothic', sans-serif;
   position: relative;
   padding: 110px 80px 70px;
   font-size: 24px;


### PR DESCRIPTION
## 概要

Actions 環境（ubuntu-latest）に日本語フォントがインストールされていないため、Marp/Puppeteer による PNG レンダリング（サムネイル生成）時に日本語が文字化けする問題を修正します。

## 原因

- CSS テーマのフォント指定: `'Amazon Ember', 'Helvetica Neue', Arial, sans-serif`
- **Amazon Ember** は AWS プロプライエタリフォントのため Linux 環境に存在しない
- **Helvetica Neue / Arial** は日本語グリフを持たない
- Marp CLI は Puppeteer（ヘッドレス Chromium）でスライドを PNG レンダリングするが、Chromium はシステムフォントを参照するため日本語フォントが見つからず文字化けが発生

## 変更内容

### `.github/workflows/marp-to-html-and-sync.yml`
- `checkout` 直後に `fonts-noto-cjk` インストールのステップを追加
- `fc-cache -fv` でフォントキャッシュを更新し Chromium から参照可能にする

### `themes/aws-whatsnew.css`
- フォントフォールバックに日本語フォントを追加
  - `Noto Sans CJK JP` / `Noto Sans JP`: Linux（Actions 環境）
  - `Hiragino Kaku Gothic ProN`: macOS
  - `Yu Gothic`: Windows

## テスト計画

- [ ] ワークフローを手動実行（`workflow_dispatch`）して新規スライドのサムネイルが正しく生成されることを確認
- [ ] 生成された `thumbnail.png` に日本語が正しく表示されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)