### PR TITLE
[SEO] sitemap.xml 自動生成スクリプト追加 (#19)

### DIFF
--- a/.github/scripts/generate-sitemap.mjs
+++ b/.github/scripts/generate-sitemap.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+
+/**
+ * metadata-all.json から sitemap.xml を生成するスクリプト
+ *
+ * 使い方:
+ *   node .github/scripts/generate-sitemap.mjs [metadata-all.json のパス]
+ *
+ * 出力: sitemap.xml (stdout)
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+const BASE_URL = 'https://whatsnew-marp.nnydtmg.com';
+
+function escapeXml(str) {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function buildSitemap(articles) {
+  const urls = [];
+
+  // トップページ
+  urls.push(`  <url>
+    <loc>${BASE_URL}/</loc>
+    <changefreq>daily</changefreq>
+    <priority>1.0</priority>
+  </url>`);
+
+  // 記事ページ
+  for (const article of articles) {
+    urls.push(`  <url>
+    <loc>${escapeXml(`${BASE_URL}/article/${article.id}`)}</loc>
+    <lastmod>${article.date}</lastmod>
+    <changefreq>never</changefreq>
+    <priority>0.8</priority>
+  </url>`);
+  }
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls.join('\n')}
+</urlset>
+`;
+}
+
+function main() {
+  const metadataPath = process.argv[2] || 'metadata-all.json';
+
+  if (!fs.existsSync(metadataPath)) {
+    console.error(`Error: ${metadataPath} not found`);
+    process.exit(1);
+  }
+
+  const metadata = JSON.parse(fs.readFileSync(metadataPath, 'utf-8'));
+  const articles = metadata['metadata:index']?.articles ?? [];
+
+  // 日付の降順でソート済み前提だが念のため
+  articles.sort((a, b) => b.date.localeCompare(a.date));
+
+  const sitemap = buildSitemap(articles);
+  process.stdout.write(sitemap);
+
+  console.error(`Generated sitemap.xml with ${articles.length} article(s)`);
+}
+
+main();

--- a/.github/workflows/marp-to-html-and-sync.yml
+++ b/.github/workflows/marp-to-html-and-sync.yml
@@ -184,6 +184,12 @@ jobs:
           node .github/scripts/generate-metadata.mjs . all > metadata-all.json
           echo "Generated metadata for $(cat metadata-all.json | jq -r '."metadata:index".totalCount') articles"
 
+      # sitemap.xml を生成
+      - name: Generate sitemap.xml
+        run: |
+          node .github/scripts/generate-sitemap.mjs metadata-all.json > sitemap.xml
+          echo "Generated sitemap.xml ($(grep -c '<url>' sitemap.xml) URLs)"
+
       # Wrangler CLIでKVを更新
       - name: Update Workers KV
         env:
@@ -242,8 +248,8 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add "**/slide.html" metadata-all.json
+          git add "**/slide.html" metadata-all.json sitemap.xml
           git add "**/thumbnail.png" || true
           git diff --quiet && git diff --staged --quiet || \
-            git commit -m "Generate HTML and metadata [skip ci]"
+            git commit -m "Generate HTML, metadata, and sitemap [skip ci]"
           git push


### PR DESCRIPTION
## Summary

- `metadata-all.json` を入力として `sitemap.xml` を生成する `.github/scripts/generate-sitemap.mjs` を追加
- CI ワークフロー（`marp-to-html-and-sync.yml`）にステップを追加し、メタデータ生成直後に `sitemap.xml` を生成してコミット

## 生成される sitemap.xml の内容

- トップページ（priority: 1.0 / changefreq: daily）
- 全記事ページ（priority: 0.8 / changefreq: never / lastmod: 記事日付）
- Base URL: `https://whatsnew-marp.nnydtmg.com`
- 記事 URL フォーマット: `/article/{id}`

## Test plan

- [x] ローカルで `node .github/scripts/generate-sitemap.mjs metadata-all.json` を実行し、32件の URL を含む有効な XML が出力されることを確認済み
- [ ] CI 実行後に `sitemap.xml` がリポジトリルートにコミットされること
- [ ] marp-site #26（動的生成ルート）完了後、`https://whatsnew-marp.nnydtmg.com/sitemap.xml` が 200 で返ること

Closes #19